### PR TITLE
Add GPU benchmarks, use block size parameter as work group size

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,24 +48,30 @@ cmake --build build
 
 ## Examples
 
-**Multi-threaded grid convolution**
+**CPU Multi-threaded grid convolution**
 
 ```bash
 ./bmp-conv -cpu image.bmp --filter=gg --mode=by_grid --threadnum=4 --block=16
 ```
 
-**Queue-based batch processing**
+**CPU Queue-based batch processing**
 
 ```bash
 ./bmp-conv -queue-mode img1.bmp img2.bmp img3.bmp \
   --filter=bb --mode=by_row --block=5 --rww=1,2,1
 ```
 
-**MPI execution (4 processes)**
+**CPU MPI execution (4 processes)**
 
 ```bash
 mpirun -np 4 ./bmp-conv -cpu -mpi-mode image.bmp \
   --filter=em --mode=by_column --block=5
+```
+
+**GPU execution (auto-defined work-group size)**
+
+```bash
+./bmp-conv -gpu image.bmp --filter=gg
 ```
 
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -55,6 +55,9 @@ Block size for row/column/grid modes.
 * `size > 0`
 * `1` enables pixel-based processing
 
+Supported in `-gpu` mode and stands for work-group size (in terms of work-items).
+If isn't passed - is chosen automatically by OpenCL.
+
 ---
 
 ## Multithreading Options

--- a/src/backend/gpu/core/mw-exec.c
+++ b/src/backend/gpu/core/mw-exec.c
@@ -124,13 +124,26 @@ double opencl_execute_basic_computation(struct img_spec *img_spec, struct p_args
 
     if (err != CL_SUCCESS) { log_error("Failed to set kernel args"); free(flat_input); free(flat_weights); return 0; }
 
-    // Enqueue (1 work item per 1 pixel)
+    // Enqueue (1 work item per 1 pixel). Optional: --block sets OpenCL local work group size.
+    // When block == 0: local_ptr = NULL → implementation chooses work group size automatically.
     size_t global_work_size[2];
-    global_work_size[0] = width;
-    global_work_size[1] = height;
+    size_t local_work_size[2];
+    size_t *local_ptr = NULL;
+    int block = args->compute_cfg.block_size > 0 ? args->compute_cfg.block_size : 0;
+
+    if (block > 0) {
+	    global_work_size[0] = (size_t)((width + block - 1) / block) * (size_t)block;
+	    global_work_size[1] = (size_t)((height + block - 1) / block) * (size_t)block;
+	    local_work_size[0] = (size_t)block;
+	    local_work_size[1] = (size_t)block;
+	    local_ptr = local_work_size;
+    } else {
+	    global_work_size[0] = (size_t)width;
+	    global_work_size[1] = (size_t)height;
+    }
 
     cl_event event;
-    err = clEnqueueNDRangeKernel(queue, kernel, 2, NULL, global_work_size, NULL, 0, NULL, &event);
+    err = clEnqueueNDRangeKernel(queue, kernel, 2, NULL, global_work_size, local_ptr, 0, NULL, &event);
     if (err != CL_SUCCESS) {
 		log_error("Failed to enqueue kernel");
 		free(flat_input);

--- a/src/backend/gpu/core/mw-exec.c
+++ b/src/backend/gpu/core/mw-exec.c
@@ -63,7 +63,7 @@ double opencl_execute_basic_computation(struct img_spec *img_spec, struct p_args
 
 	if (strcmp(args->compute_cfg.filter_type, "mm") == 0)
 		kernel = clCreateKernel(program, "apply_mm_filter_kernel", &err);
-	else 
+	else
 		kernel = clCreateKernel(program, "apply_filter_kernel", &err);
 
     if (err != CL_SUCCESS) { log_error("Failed to create kernel"); return 0; }
@@ -72,21 +72,24 @@ double opencl_execute_basic_computation(struct img_spec *img_spec, struct p_args
     int width = img_spec->dim->width;
     int height = img_spec->dim->height;
     int num_pixels = width * height;
+    size_t img_size_bytes = num_pixels * 3 * sizeof(unsigned char); // Explicitly 3 bytes per pixel
 
-    size_t img_size_bytes = num_pixels * sizeof(bmp_pixel);
-    bmp_pixel* flat_input = malloc(img_size_bytes);
+    unsigned char* flat_input = malloc(img_size_bytes);
     if (!flat_input) { log_error("Malloc failed"); return 0; }
 
     for (int y = 0; y < height; y++) {
         for (int x = 0; x < width; x++) {
-            flat_input[y * width + x] = img_spec->input->img_pixels[y][x];
+            int idx = (y * width + x) * 3;
+            flat_input[idx]     = img_spec->input->img_pixels[y][x].blue;
+            flat_input[idx + 1] = img_spec->input->img_pixels[y][x].green;
+            flat_input[idx + 2] = img_spec->input->img_pixels[y][x].red;
         }
     }
 
     // Create Buffers
     input_buf = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, img_size_bytes, flat_input, &err);
     if (err != CL_SUCCESS) { log_error("Failed to create input buffer"); free(flat_input); return 0; }
-    
+
     output_buf = clCreateBuffer(context, CL_MEM_WRITE_ONLY, img_size_bytes, NULL, &err);
     if (err != CL_SUCCESS) { log_error("Failed to create output buffer"); free(flat_input); return 0; }
 
@@ -107,13 +110,17 @@ double opencl_execute_basic_computation(struct img_spec *img_spec, struct p_args
     weights_buf = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, weights_size, flat_weights, &err);
     if (err != CL_SUCCESS) { log_error("Failed to create weights buffer"); free(flat_input); free(flat_weights); return 0; }
 
-    err  = clSetKernelArg(kernel, 0, sizeof(cl_mem), &input_buf);
-    err |= clSetKernelArg(kernel, 1, sizeof(cl_mem), &output_buf);
+	float factor_f = (float)f->factor;
+    float bias_f = (float)f->bias;
+	err  = clSetKernelArg(kernel, 0, sizeof(cl_mem), &input_buf);
+	err |= clSetKernelArg(kernel, 1, sizeof(cl_mem), &output_buf);
 	err |= clSetKernelArg(kernel, 2, sizeof(int), &width);
 	err |= clSetKernelArg(kernel, 3, sizeof(int), &height);
-    err |= clSetKernelArg(kernel, 4, sizeof(cl_mem), &weights_buf);
-	err |= clSetKernelArg(kernel, 5, sizeof(int), &f->factor);
-	err |= clSetKernelArg(kernel, 6, sizeof(int), &f->bias);
+	err |= clSetKernelArg(kernel, 4, sizeof(cl_mem), &weights_buf);
+	err |= clSetKernelArg(kernel, 5, sizeof(int), &f->size);
+	err |= clSetKernelArg(kernel, 6, sizeof(float), &factor_f);
+	err |= clSetKernelArg(kernel, 7, sizeof(float), &bias_f);
+
 
     if (err != CL_SUCCESS) { log_error("Failed to set kernel args"); free(flat_input); free(flat_weights); return 0; }
 
@@ -124,7 +131,12 @@ double opencl_execute_basic_computation(struct img_spec *img_spec, struct p_args
 
     cl_event event;
     err = clEnqueueNDRangeKernel(queue, kernel, 2, NULL, global_work_size, NULL, 0, NULL, &event);
-    if (err != CL_SUCCESS) { log_error("Failed to enqueue kernel"); free(flat_input); free(flat_weights); return 0; }
+    if (err != CL_SUCCESS) {
+		log_error("Failed to enqueue kernel");
+		free(flat_input);
+		free(flat_weights);
+		return 0;
+	}
 
     clWaitForEvents(1, &event);
 
@@ -134,13 +146,18 @@ double opencl_execute_basic_computation(struct img_spec *img_spec, struct p_args
     double time_seconds = (double)(end - start) / 1e9;
 
     // Read Result
-    bmp_pixel* flat_output = malloc(img_size_bytes);
     err = clEnqueueReadBuffer(queue, output_buf, CL_TRUE, 0, img_size_bytes, flat_output, 0, NULL, NULL);
+	unsigned char* flat_output = malloc(img_size_bytes);
+    clEnqueueReadBuffer(queue, output_buf, CL_TRUE, 0, img_size_bytes, flat_output, 0, NULL, NULL);
     if (err != CL_SUCCESS) { log_error("Failed to read buffer"); free(flat_input); free(flat_weights); free(flat_output); return 0; }
 
     for (int y = 0; y < height; y++) {
         for (int x = 0; x < width; x++) {
-            img_spec->output->img_pixels[y][x] = flat_output[y * width + x];
+            int idx = (y * width + x) * 3;
+            // Unpack back to struct
+            img_spec->output->img_pixels[y][x].blue  = flat_output[idx];
+            img_spec->output->img_pixels[y][x].green = flat_output[idx + 1];
+            img_spec->output->img_pixels[y][x].red   = flat_output[idx + 2];
         }
     }
 

--- a/src/backend/gpu/core/mw-exec.c
+++ b/src/backend/gpu/core/mw-exec.c
@@ -159,9 +159,8 @@ double opencl_execute_basic_computation(struct img_spec *img_spec, struct p_args
     double time_seconds = (double)(end - start) / 1e9;
 
     // Read Result
-    err = clEnqueueReadBuffer(queue, output_buf, CL_TRUE, 0, img_size_bytes, flat_output, 0, NULL, NULL);
 	unsigned char* flat_output = malloc(img_size_bytes);
-    clEnqueueReadBuffer(queue, output_buf, CL_TRUE, 0, img_size_bytes, flat_output, 0, NULL, NULL);
+    err = clEnqueueReadBuffer(queue, output_buf, CL_TRUE, 0, img_size_bytes, flat_output, 0, NULL, NULL);
     if (err != CL_SUCCESS) { log_error("Failed to read buffer"); free(flat_input); free(flat_weights); free(flat_output); return 0; }
 
     for (int y = 0; y < height; y++) {

--- a/src/bmp-conv.c
+++ b/src/bmp-conv.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/* TODO: make log_file path as a param */
 #define LOG_FILE_PATH "tests/timing-results.dat"
 
 // Global pointer to parsed arguments. Consider passing this instead of using global.
@@ -45,7 +46,7 @@ int main(int argc, char *argv[])
 		free(args);
 		return -1;
 	}
-	
+
 	filters = setup_filters(args);
 	if (!filters) {
 		free(args);

--- a/src/utils/threads-general.c
+++ b/src/utils/threads-general.c
@@ -322,15 +322,15 @@ void filter_part_computation(struct thread_spec *spec)
 }
 
 struct filter* get_filter_by_name(struct filter_mix *filters, const char* name) {
-    if (strcmp(name, "blur") == 0) return filters->blur;
-    if (strcmp(name, "motion_blur") == 0) return filters->motion_blur;
-    if (strcmp(name, "gaus_blur") == 0) return filters->gaus_blur;
-    if (strcmp(name, "conv") == 0) return filters->conv;
-    if (strcmp(name, "sharpen") == 0) return filters->sharpen;
-    if (strcmp(name, "emboss") == 0) return filters->emboss;
-    if (strcmp(name, "big_gaus") == 0) return filters->big_gaus;
-    if (strcmp(name, "med_gaus") == 0) return filters->med_gaus;
-    if (strcmp(name, "box_blur") == 0) return filters->box_blur;
+    if (strcmp(name, "bb") == 0) return filters->blur;
+    if (strcmp(name, "mb") == 0) return filters->motion_blur;
+    if (strcmp(name, "gb") == 0) return filters->gaus_blur;
+    if (strcmp(name, "co") == 0) return filters->conv;
+    if (strcmp(name, "sh") == 0) return filters->sharpen;
+    if (strcmp(name, "em") == 0) return filters->emboss;
+    if (strcmp(name, "gg") == 0) return filters->big_gaus;
+    if (strcmp(name, "mg") == 0) return filters->med_gaus;
+    if (strcmp(name, "bo") == 0) return filters->box_blur;
     return NULL;
 }
 
@@ -342,6 +342,8 @@ void save_result_image(char *output_filepath, size_t path_len, int threadnum, bm
 		snprintf(output_filepath, path_len, "test-img/%s", args->files_cfg.output_filename);
 	} else if (args->compute_cfg.mpi == CONV_MPI_ENABLED) {
 		snprintf(output_filepath, path_len, "test-img/mpi_out_%s", args->files_cfg.input_filename[0]);
+	} else if (args->compute_cfg.backend == CONV_BACKEND_GPU) {
+		snprintf(output_filepath, path_len, "test-img/gpu_out_%s", args->files_cfg.input_filename[0]);
 	} else {
 		if (threadnum > 1) {
 			snprintf(output_filepath, path_len, "test-img/rcon_out_%s", args->files_cfg.input_filename[0]);
@@ -350,14 +352,14 @@ void save_result_image(char *output_filepath, size_t path_len, int threadnum, bm
 		}
 	}
 
-	log_debug("Result out filepath %s\n", output_filepath);
+	log_debug("Result image is written by filepath: %s\n", output_filepath);
 
 	if (!img_result->img_pixels)
 		log_error("Pointer to images pixel array is NULL");
 
 	status = bmp_img_write(img_result, output_filepath);
 
-	log_debug("status %d", status);
+	log_debug("bmp_img_write status %d", status);
 }
 
 void free_img_spec(struct img_spec *img_data)

--- a/tests/arm-benchmark.sh
+++ b/tests/arm-benchmark.sh
@@ -1,24 +1,34 @@
 #!/bin/bash
 
+SD=$(dirname "$(realpath "$0")")
+BASEDIR=$(dirname "$SD")
+BD="$BASEDIR"
+BUILD_DIR="${BUILD_DIR:-$BD/build}"
+
 ITERATIONS=40
 INPUT_FILE="image4.bmp"
 FILTER_TYPE="gg"
 THREAD_NUM=4
 COMPUTE_MODE="by_grid"
 BLOCK_SIZE=32
-MAKE_DIR="../"
 
-MAKE_CMD_ECORES="make -C ${MAKE_DIR} run-mac-e-cores"
-MAKE_CMD_PCORES="make -C ${MAKE_DIR} run-mac-p-cores" # Or 'make run'
+if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+    cmake -B "$BUILD_DIR"
+fi
+cmake --build "$BUILD_DIR"
 
-MAKE_PARAMS="INPUT_TF=${INPUT_FILE} FILTER_TYPE=${FILTER_TYPE} THREAD_NUM=${THREAD_NUM} COMPUTE_MODE=${COMPUTE_MODE} BLOCK_SIZE=${BLOCK_SIZE}"
+BIN="$BUILD_DIR/bmp-conv"
+if [[ ! -x "$BIN" ]]; then
+    echo "Error: executable not found: $BIN"
+    exit 1
+fi
 
 e_core_times=()
 p_core_times=()
 
 extract_time() {
   local output="$1"
-  echo -e "$output" | grep 'RESULT:.*time = ' | awk '{print $(NF-1)}'
+  echo -e "$output" | grep -E 'RESULT:.*time|time=.*seconds' | awk '{print $(NF-1)}'
 }
 
 calculate_stats() {
@@ -65,11 +75,12 @@ calculate_stats() {
   echo -e "$stats"
 }
 
-echo -e "\nRunning tests on E-cores (${ITERATIONS} times)"
+cd "$BD" || exit 1
 
+echo -e "\nRunning tests on E-cores (${ITERATIONS} times)"
 for (( i=1; i<=ITERATIONS; i++ )); do
   echo -e "Running E-cores $i/$ITERATIONS... "
-  output=$(eval "${MAKE_CMD_ECORES} ${MAKE_PARAMS}" 2>&1)
+  output=$(taskpolicy -c background "$BIN" -cpu "$INPUT_FILE" --filter="$FILTER_TYPE" --threadnum="$THREAD_NUM" --mode="$COMPUTE_MODE" --block="$BLOCK_SIZE" --log=0 2>&1)
   time_val=$(extract_time "$output")
 
   if [[ "$time_val" =~ ^[0-9.]+$ ]]; then
@@ -81,10 +92,9 @@ for (( i=1; i<=ITERATIONS; i++ )); do
 done
 
 echo -e "\nRunning tests on P-cores (${ITERATIONS} times)"
-
 for (( i=1; i<=ITERATIONS; i++ )); do
   echo -e "Running P-cores $i/$ITERATIONS... "
-  output=$(eval "${MAKE_CMD_PCORES} ${MAKE_PARAMS}" 2>&1)
+  output=$("$BIN" -cpu "$INPUT_FILE" --filter="$FILTER_TYPE" --threadnum="$THREAD_NUM" --mode="$COMPUTE_MODE" --block="$BLOCK_SIZE" --log=0 2>&1)
   time_val=$(extract_time "$output")
 
   if [[ "$time_val" =~ ^[0-9.]+$ ]]; then

--- a/tests/gpu-benchmark.sh
+++ b/tests/gpu-benchmark.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+SD=$(dirname "$(realpath "$0")")   # script directory (tests/)
+BASEDIR=$(dirname "$SD")          # project root
+BD="$BASEDIR"
+BUILD_DIR="${BUILD_DIR:-$BD/build}"
+
+LOG_FILE="$SD/timing-results.dat"
+PLOTS_PATH="$SD/plots/"
+RUN_NUM=25
+
+TEST_FILE="image-7.bmp"
+FILTERS=("co" "sh" "bb" "gb" "em" "mb" "mg" "gg" "bo") # mm can be added, but has too high execution time (x20)
+BLOCK_SIZE_GPU=(1 4 8 16 32 64 128)
+
+# Build with cmake (configure if needed)
+if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+	cmake -B "$BUILD_DIR" -DENABLE_OPENCL=ON
+fi
+cmake --build "$BUILD_DIR"
+
+BIN="$BUILD_DIR/bmp-conv"
+if [[ ! -x "$BIN" ]]; then
+	echo "Error: executable not found: $BIN"
+	exit 1
+fi
+
+cd "$BD" || exit 1
+echo "RunID Filter-type Thread-num Mode Block-size Result" > "$LOG_FILE"
+mkdir -p "$PLOTS_PATH" "$PLOTS_PATH/mt" "$PLOTS_PATH/st"
+
+if [[ ! -e "$TEST_FILE" ]]; then
+	convert -size 16000x16000 pattern:checkerboard "$TEST_FILE" 2>/dev/null || \
+		convert -size 16000x16000 pattern:checkerboard checker.bmp && TEST_FILE="checker.bmp"
+fi
+
+echo -e "\nRunning GPU tests (block size = work group size)"
+for fil in "${FILTERS[@]}"; do
+	for bs in "${BLOCK_SIZE_GPU[@]}"; do
+		for i in $(seq 1 "$RUN_NUM"); do
+			echo -n "$i " >> "$LOG_FILE"
+			"$BIN" -gpu "$TEST_FILE" --filter="$fil" --mode=by_row --block="$bs" --log=1
+		done
+	done
+done
+
+python3 "$SD/avg-plots.py"
+python3 "$SD/gpu-plots.py"

--- a/tests/gpu-plots.py
+++ b/tests/gpu-plots.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Generate plots for GPU benchmark results.
+Reads timing-results.dat and plots rows where BLOCK_SIZE is in GPU block set (4,8,16,32,64,128).
+Run from project root: python3 tests/gpu-plots.py
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
+import os
+import scipy.stats as stats
+
+RESULTS_FILE = "tests/timing-results.dat"
+PLOTS_PATH = "tests/plots/gpu/"
+
+# Block sizes used in gpu-benchmark.sh — only these rows are treated as GPU runs
+GPU_BLOCK_SIZES = (1, 4, 8, 16, 32, 64, 128)
+
+FILTER_DISPLAY_NAMES = {
+    "mb": "Motion Blur",
+    "bb": "Basic Blur",
+    "gb": "Gaussian Blur",
+    "em": "Emboss",
+    "mm": "Median",
+    "sh": "Sharpen",
+    "bo": "Box Blur",
+    "mg": "Medium Gaussian",
+    "gg": "Big Gaussian",
+    "co": "Convolution",
+}
+
+plt.rcParams.update({
+    "axes.titlesize": 14,
+    "axes.labelsize": 12,
+    "xtick.labelsize": 10,
+    "ytick.labelsize": 10,
+})
+
+
+def load_gpu_df():
+    if not os.path.isfile(RESULTS_FILE):
+        raise FileNotFoundError(f"Results file not found: {RESULTS_FILE} (run from project root)")
+    df = pd.read_csv(
+        RESULTS_FILE,
+        sep=r"\s+",
+        names=["RunID", "FILTER", "THREADNUM", "MODE", "BLOCK_SIZE", "TIME"],
+    )
+    df["TIME"] = pd.to_numeric(df["TIME"], errors="coerce")
+    df["BLOCK_SIZE"] = pd.to_numeric(df["BLOCK_SIZE"], errors="coerce")
+    df = df.dropna(subset=["TIME", "BLOCK_SIZE"])
+    gpu = df[df["BLOCK_SIZE"].isin(GPU_BLOCK_SIZES)].copy()
+    return gpu
+
+
+def confidence_interval_half(data):
+    data = data.dropna()
+    if len(data) < 2:
+        return 0.0
+    mean, sigma = np.mean(data), np.std(data)
+    ci = stats.t.interval(0.95, len(data) - 1, loc=mean, scale=stats.sem(data))
+    return (ci[1] - ci[0]) / 2.0
+
+
+def plot_time_vs_block_size(gpu_df):
+    """Time vs block size (work group size) per filter — main GPU benchmark plot."""
+    os.makedirs(PLOTS_PATH, exist_ok=True)
+    filters = sorted(gpu_df["FILTER"].unique())
+    if not filters:
+        print("No GPU data found (BLOCK_SIZE in 4,8,16,32,64,128). Skip time vs block size.")
+        return
+
+    fig, ax = plt.subplots(figsize=(12, 7), dpi=150)
+    block_order = sorted(gpu_df["BLOCK_SIZE"].unique(), key=int)
+
+    for f in filters:
+        sub = gpu_df[gpu_df["FILTER"] == f].groupby("BLOCK_SIZE")["TIME"]
+        means = sub.mean().reindex(block_order)
+        errs = sub.apply(confidence_interval_half).reindex(block_order)
+        means = means.fillna(0)
+        errs = errs.fillna(0)
+        label = FILTER_DISPLAY_NAMES.get(f, f)
+        ax.errorbar(
+            block_order,
+            means,
+            yerr=errs,
+            marker="o",
+            capsize=4,
+            label=label,
+        )
+
+    ax.set_xlabel("Block size (work group size)")
+    ax.set_ylabel("Execution time (s)")
+    ax.set_title("GPU: execution time vs block size (OpenCL work group)")
+    ax.set_xticks(block_order)
+    ax.legend(loc="best", fontsize=9)
+    ax.grid(True, linestyle="--", alpha=0.6)
+    fig.tight_layout()
+    path = os.path.join(PLOTS_PATH, "gpu_time_vs_block_size.png")
+    fig.savefig(path, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {path}")
+
+
+def plot_mean_time_per_filter(gpu_df):
+    """Bar chart: mean execution time per filter (averaged over block sizes)."""
+    if gpu_df.empty:
+        return
+    os.makedirs(PLOTS_PATH, exist_ok=True)
+    by_filter = gpu_df.groupby("FILTER")["TIME"]
+    means = by_filter.mean()
+    errs = by_filter.apply(confidence_interval_half)
+    labels = [FILTER_DISPLAY_NAMES.get(f, f) for f in means.index]
+
+    fig, ax = plt.subplots(figsize=(12, 6), dpi=150)
+    x = np.arange(len(means))
+    ax.bar(x, means.values, yerr=errs.values, capsize=5)
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=45, ha="right")
+    ax.set_ylabel("Mean execution time (s)")
+    ax.set_title("GPU: mean execution time per filter (all block sizes)")
+    fig.tight_layout()
+    path = os.path.join(PLOTS_PATH, "gpu_mean_time_per_filter.png")
+    fig.savefig(path, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {path}")
+
+
+def plot_per_filter_block_bars(gpu_df):
+    """One bar chart per filter: time vs block size (for detailed per-filter view)."""
+    if gpu_df.empty:
+        return
+    os.makedirs(PLOTS_PATH, exist_ok=True)
+    subdir = os.path.join(PLOTS_PATH, "per_filter")
+    os.makedirs(subdir, exist_ok=True)
+    block_order = sorted(gpu_df["BLOCK_SIZE"].unique(), key=int)
+
+    for f in gpu_df["FILTER"].unique():
+        sub = gpu_df[gpu_df["FILTER"] == f]
+        by_block = sub.groupby("BLOCK_SIZE")["TIME"]
+        means = by_block.mean().reindex(block_order).fillna(0)
+        errs = by_block.apply(confidence_interval_half).reindex(block_order).fillna(0)
+
+        fig, ax = plt.subplots(figsize=(8, 5), dpi=150)
+        ax.bar(means.index.astype(int).astype(str), means.values, yerr=errs.values, capsize=5)
+        ax.set_xlabel("Block size")
+        ax.set_ylabel("Execution time (s)")
+        ax.set_title(f"GPU: {FILTER_DISPLAY_NAMES.get(f, f)} — time vs block size")
+        fig.tight_layout()
+        path = os.path.join(subdir, f"gpu_{f}_time_vs_block.png")
+        fig.savefig(path, bbox_inches="tight")
+        plt.close(fig)
+        print(f"Saved: {path}")
+
+
+def main():
+    gpu_df = load_gpu_df()
+    if gpu_df.empty:
+        print("No GPU benchmark rows in timing-results.dat (expected BLOCK_SIZE in 4,8,16,32,64,128).")
+        return
+    plot_time_vs_block_size(gpu_df)
+    plot_mean_time_per_filter(gpu_df)
+    plot_per_filter_block_bars(gpu_df)
+    print("GPU plotting complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gpu-plots.py
+++ b/tests/gpu-plots.py
@@ -30,17 +30,21 @@ FILTER_DISPLAY_NAMES = {
     "co": "Convolution",
 }
 
-plt.rcParams.update({
-    "axes.titlesize": 14,
-    "axes.labelsize": 12,
-    "xtick.labelsize": 10,
-    "ytick.labelsize": 10,
-})
+plt.rcParams.update(
+    {
+        "axes.titlesize": 14,
+        "axes.labelsize": 12,
+        "xtick.labelsize": 10,
+        "ytick.labelsize": 10,
+    }
+)
 
 
 def load_gpu_df():
     if not os.path.isfile(RESULTS_FILE):
-        raise FileNotFoundError(f"Results file not found: {RESULTS_FILE} (run from project root)")
+        raise FileNotFoundError(
+            f"Results file not found: {RESULTS_FILE} (run from project root)"
+        )
     df = pd.read_csv(
         RESULTS_FILE,
         sep=r"\s+",
@@ -67,7 +71,9 @@ def plot_time_vs_block_size(gpu_df):
     os.makedirs(PLOTS_PATH, exist_ok=True)
     filters = sorted(gpu_df["FILTER"].unique())
     if not filters:
-        print("No GPU data found (BLOCK_SIZE in 4,8,16,32,64,128). Skip time vs block size.")
+        print(
+            "No GPU data found (BLOCK_SIZE in 4,8,16,32,64,128). Skip time vs block size."
+        )
         return
 
     fig, ax = plt.subplots(figsize=(12, 7), dpi=150)
@@ -89,7 +95,7 @@ def plot_time_vs_block_size(gpu_df):
             label=label,
         )
 
-    ax.set_xlabel("Block size (work group size)")
+    ax.set_xlabel("Work group size)")
     ax.set_ylabel("Execution time (s)")
     ax.set_title("GPU: execution time vs block size (OpenCL work group)")
     ax.set_xticks(block_order)
@@ -142,7 +148,12 @@ def plot_per_filter_block_bars(gpu_df):
         errs = by_block.apply(confidence_interval_half).reindex(block_order).fillna(0)
 
         fig, ax = plt.subplots(figsize=(8, 5), dpi=150)
-        ax.bar(means.index.astype(int).astype(str), means.values, yerr=errs.values, capsize=5)
+        ax.bar(
+            means.index.astype(int).astype(str),
+            means.values,
+            yerr=errs.values,
+            capsize=5,
+        )
         ax.set_xlabel("Block size")
         ax.set_ylabel("Execution time (s)")
         ax.set_title(f"GPU: {FILTER_DISPLAY_NAMES.get(f, f)} — time vs block size")
@@ -156,7 +167,9 @@ def plot_per_filter_block_bars(gpu_df):
 def main():
     gpu_df = load_gpu_df()
     if gpu_df.empty:
-        print("No GPU benchmark rows in timing-results.dat (expected BLOCK_SIZE in 4,8,16,32,64,128).")
+        print(
+            "No GPU benchmark rows in timing-results.dat (expected BLOCK_SIZE in 1,4,8,16,32,64,128)."
+        )
         return
     plot_time_vs_block_size(gpu_df)
     plot_mean_time_per_filter(gpu_df)

--- a/tests/mpi-benchmark.sh
+++ b/tests/mpi-benchmark.sh
@@ -1,27 +1,39 @@
 #!/bin/bash
 
-SD=$(dirname "$(realpath "$0")") # script directory
-BASEDIR=$(dirname "$SD")  # Parent directory of script's location
+SD=$(dirname "$(realpath "$0")")
+BASEDIR=$(dirname "$SD")
 BD="$BASEDIR"
+BUILD_DIR="${BUILD_DIR:-$BD/build}"
 
-LOG_FILE="$SD/timing-results.dat" 
+LOG_FILE="$SD/timing-results.dat"
 PLOTS_PATH="$SD/plots/"
 RUN_NUM=25
 
-TEST_FILE="image7.bmp" # as a small image - image6.bmp was used
-# image 7 isn't presented in the repo, it will be generated with the "magick" tool
+TEST_FILE="image7.bmp"
 FILTER="gg"
-BLOCK_SIZE=("4" "8" "16" "32" "64" "128")
-PROC_NUMS=("2" "3" "4" "5" "6" "7" "8")
+BLOCK_SIZE=(4 8 16 32 64 128)
+PROC_NUMS=(2 3 4 5 6 7 8)
 MODES=("by_row" "by_column")
 
-make -C "$BD" build-f 
+if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+    cmake -B "$BUILD_DIR" -DENABLE_MPI=ON
+fi
+cmake --build "$BUILD_DIR"
+
+BIN="$BUILD_DIR/bmp-conv"
+if [[ ! -x "$BIN" ]]; then
+    echo "Error: executable not found: $BIN"
+    exit 1
+fi
 
 echo "RunID Process-num Filter ThreadNum_logged Mode Block-size Result" > "$LOG_FILE"
 
-echo -e "Generating $TEST_FILE with the size = 1GB..."
-magick -size 16384x16384 xc:black "$SD"/../test-img/image7.bmp
+echo "Generating $TEST_FILE (1GB)..."
+mkdir -p "$BD/test-img"
+magick -size 16384x16384 xc:black "$BD/test-img/$TEST_FILE" 2>/dev/null || \
+    convert -size 16384x16384 xc:black "$BD/test-img/$TEST_FILE"
 
+cd "$BD" || exit 1
 mkdir -p "$PLOTS_PATH/mpi"
 echo -e "\nRunning MPI tests"
 
@@ -30,11 +42,8 @@ for proc_num in "${PROC_NUMS[@]}"; do
         for bs in "${BLOCK_SIZE[@]}"; do
             for i in $(seq 1 "$RUN_NUM"); do
                 echo -n "$i $proc_num " >> "$LOG_FILE"
-
-                make -C "$BD" run-mpi-mode MPI_NP="$proc_num" \
-                     VALGRIND_PREFIX="" INPUT_TF="$TEST_FILE" \
-                     FILTER_TYPE="$FILTER" BLOCK_SIZE="$bs" \
-                     COMPUTE_MODE="$mode" THREADNUM="1" 
+                mpirun -np "$proc_num" "$BIN" -cpu -mpi "test-img/$TEST_FILE" \
+                    --filter="$FILTER" --mode="$mode" --block="$bs" --log=1
             done
         done
     done

--- a/tests/qmt-benchmark.sh
+++ b/tests/qmt-benchmark.sh
@@ -1,34 +1,43 @@
 #!/bin/bash
 
 SD=$(dirname "$(realpath "$0")")
-BASEDIR=$(dirname "$SD")  
+BASEDIR=$(dirname "$SD")
 BD="$BASEDIR"
+BUILD_DIR="${BUILD_DIR:-$BD/build}"
 PLOTS_PATH="$SD/plots/"
 FILES_COUNT=20
 RUN_NUM=25
-QTHREADSMIX=("1,1,1" "2,2,2" "3,3,3" "5,5,5" "1,2,1" "1,1,2" "2,1,1" "1,2,2" "3,2,2" "2,3,3"  "1,3,3" "1,4,4" "1,6,6" )
-MODES=("by_row" "by_column" "by_grid") # removed by_pixel due to too big execution time
+QTHREADSMIX=("1,1,1" "2,2,2" "3,3,3" "5,5,5" "1,2,1" "1,1,2" "2,1,1" "1,2,2" "3,2,2" "2,3,3" "1,3,3" "1,4,4" "1,6,6")
+MODES=("by_row" "by_column" "by_grid")
+
+if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+    cmake -B "$BUILD_DIR"
+fi
+cmake --build "$BUILD_DIR"
+
+BIN="$BUILD_DIR/bmp-conv"
+if [[ ! -x "$BIN" ]]; then
+    echo "Error: executable not found: $BIN"
+    exit 1
+fi
 
 clean_plot_dir() {
 	rm -rf "$PLOTS_PATH"/q-mode/*.png
 }
 
-set_input_images() {
-	input=""
-	for ((i=1; i<=FILES_COUNT; i++)); do
-		input+="image4.bmp "
-	done
-	echo "$input"
-}
+INPUT_FILES=()
+for ((i=1; i<=FILES_COUNT; i++)); do
+	INPUT_FILES+=(image4.bmp)
+done
 
 clean_plot_dir
-set_input_images
+cd "$BD" || exit 1
 
 for mode in "${MODES[@]}"; do
-	for mix in "${QTHREADSMIX[@]}"; do 
-		rm -rf "$SD/queue-timings.dat"
+	for mix in "${QTHREADSMIX[@]}"; do
+		rm -f "$SD/queue-timings.dat"
 		for i in $(seq 1 "$RUN_NUM"); do
-			make -C "$BD" run-q-mode VALGRIND_PREFIX="" COMPUTE_MODE="$mode" INPUT_TF="$input" FILTER_TYPE=gg BLOCK_SIZE=15 RWW_MIX="$mix"
+			"$BIN" -queue-mode "${INPUT_FILES[@]}" --mode="$mode" --filter=gg --block=15 --rww="$mix" --log=1
 		done
 		python3 "$SD/qmt-plots.py" --mix="$mix"
 	done

--- a/tests/st-mt-benchmark.sh
+++ b/tests/st-mt-benchmark.sh
@@ -1,77 +1,75 @@
 #!/bin/bash
 
-SD=$(dirname "$(realpath "$0")") # script directory
-BASEDIR=$(dirname "$SD")  # Parent directory of script's location
+SD=$(dirname "$(realpath "$0")")
+BASEDIR=$(dirname "$SD")
 BD="$BASEDIR"
+BUILD_DIR="${BUILD_DIR:-$BD/build}"
 
 LOG_FILE="$SD/timing-results.dat"
 PLOTS_PATH="$SD/plots/"
 RUN_NUM=25
 
 TEST_FILE="image5.bmp"
-FILTERS=( "co" "sh" "bb" "gb" "em" "mb" "mg" "gg" "bo") # mm can be added, but has too high execution time (x20)
-BLOCK_SIZE=("4" "8" "16" "32" "64" "128")
+FILTERS=(co sh bb gb em mb mg gg bo)
+BLOCK_SIZE=(4 8 16 32 64 128)
 THREADNUM=4
-MODES=("by_row" "by_column" "by_grid") # removed by_pixel due to too big execution time
+MODES=("by_row" "by_column" "by_grid")
 FILTER_PAIRS="gb,sh sh,gb mb,sh sh,mb gg,sh sh,gg"
 
 IFS=' ' read -r -a pairs <<< "$FILTER_PAIRS"
 
-for pair in "${pairs[@]}"; do
-    IFS=',' read -r f1 f2 <<< "$pair"
-    echo "f1: $f1, f2: $f2"
-done
+if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]; then
+    cmake -B "$BUILD_DIR"
+fi
+cmake --build "$BUILD_DIR"
 
-make -C "$BD" build-f
+BIN="$BUILD_DIR/bmp-conv"
+if [[ ! -x "$BIN" ]]; then
+    echo "Error: executable not found: $BIN"
+    exit 1
+fi
 
+cd "$BD" || exit 1
 echo "RunID Filter-type Thread-num Mode Block-size Result" > "$LOG_FILE"
-
 mkdir -p "$PLOTS_PATH" "$PLOTS_PATH/mt" "$PLOTS_PATH/st"
 
 echo -e "\nRunning single-threaded tests"
 for fil in "${FILTERS[@]}"; do
-	echo "$BD"
-
 	for i in $(seq 1 "$RUN_NUM"); do
 		echo -n "$i " >> "$LOG_FILE"
-		make -C "$BD" run-mac-p-cores INPUT_TF="$TEST_FILE" FILTER_TYPE="$fil" THREAD_NUM=1 
+		"$BIN" -cpu "$TEST_FILE" --filter="$fil" --mode=by_row --block=1 --threadnum=1 --log=1
 	done
 done
 
-python3 "$SD/avg_plots.py"
+python3 "$SD/avg-plots.py"
 
 echo -e "\nRunning multithreaded tests"
 for mode in "${MODES[@]}"; do
 	for fil in "${FILTERS[@]}"; do
 		for bs in "${BLOCK_SIZE[@]}"; do
-
 			for i in $(seq 1 "$RUN_NUM"); do
 				echo -n "$i " >> "$LOG_FILE"
-				make -C "$BD" run-mac-p-cores INPUT_TF="$TEST_FILE" FILTER_TYPE="$fil" THREAD_NUM="$THREADNUM" BLOCK_SIZE="$bs" COMPUTE_MODE="$mode"
+				"$BIN" -cpu "$TEST_FILE" --filter="$fil" --threadnum="$THREADNUM" --block="$bs" --mode="$mode" --log=1
 			done
 		done
 	done
 done
 
-python3 "$SD/avg_plots.py"
+python3 "$SD/avg-plots.py"
 
 echo -e "\nRunning multithreaded tests with filter composition"
 for pair in "${pairs[@]}"; do
 	IFS=',' read -r f1 f2 <<< "$pair"
-	echo -e "SEQUENTIAL MODE:\n"
+	echo "Filter pair: $f1 -> $f2"
 
-	make -C "$BD" run-mac-p-cores INPUT_TF="$TEST_FILE" FILTER_TYPE="$f1" THREADNUM=1 OUTPUT_FILE="${f1}_$TEST_FILE" LOG=0 
-	make -C "$BD" run-mac-p-cores INPUT_TF="${f1}_$TEST_FILE" FILTER_TYPE="$f2" THREADNUM=1 OUTPUT_FILE="seq_out_${f1}_${f2}_$TEST_FILE" LOG=0 
+	"$BIN" -cpu "$TEST_FILE" --filter="$f1" --threadnum=1 --mode=by_row --block=16 --log=0 --output="${f1}_$TEST_FILE"
+	"$BIN" -cpu "${f1}_$TEST_FILE" --filter="$f2" --threadnum=1 --mode=by_row --block=16 --log=0 --output="seq_out_${f1}_${f2}_$TEST_FILE"
 
 	for i in $(seq 1 "$RUN_NUM"); do
 		echo -n "$i " >> "$LOG_FILE"
-		echo -e "MULTITHREADED MODE:\n"
-
-		make -C "$BD" run-mac-p-cores INPUT_TF="$TEST_FILE" FILTER_TYPE="$f1" THREADNUM="$THREADNUM" BLOCK_SIZE=16 COMPUTE_MODE=by_grid OUTPUT_FILE="${f1}_$TEST_FILE"
+		"$BIN" -cpu "$TEST_FILE" --filter="$f1" --threadnum="$THREADNUM" --block=16 --mode=by_grid --log=0 --output="${f1}_$TEST_FILE"
 		echo -n "$i " >> "$LOG_FILE"
-		make -C "$BD" run-mac-p-cores INPUT_TF="${f1}_$TEST_FILE" FILTER_TYPE="$f2" THREADNUM="$THREADNUM" BLOCK_SIZE=16 COMPUTE_MODE=by_grid OUTPUT_FILE="rcon_out_${f1}_${f2}_$TEST_FILE"
-
-		compare_results "${f1}_${f2}_$TEST_FILE"
+		"$BIN" -cpu "${f1}_$TEST_FILE" --filter="$f2" --threadnum="$THREADNUM" --block=16 --mode=by_grid --log=0 --output="rcon_out_${f1}_${f2}_$TEST_FILE"
 	done
 done
 


### PR DESCRIPTION
TODO:
- unify log file format for every backend
- CL_DEVICE_MAX_WORK_GROUP_SIZE/CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE
- try to launch multiple file kernels on one gpu?
- beautiful cli information about the run
- queue mode for GPU
- CUDA implementation
- CUDA implementation analysis using nvidia perf tools 
- n-bufferisation
- buffer batching (one kernel for many images)
- profiling
- support other file formats
- split mode for kernel execution over very large images (i.e. >=32k-32k)